### PR TITLE
Ability to disable resolve alerts

### DIFF
--- a/bin/handler-twiliosms.rb
+++ b/bin/handler-twiliosms.rb
@@ -31,7 +31,7 @@ class TwilioSMS < Sensu::Handler
     short = settings['twiliosms']['short'] || false
     disableOk = settings['twiliosms']['disableOk'] || false
 
-    next if @event['action'].eql?('resolve') and disableOk
+    return if @event['action'].eql?('resolve') and disableOk
 
     fail 'Please define a valid Twilio authentication set to use this handler' unless account_sid && auth_token && from_number
     fail 'Please define a valid set of SMS recipients to use this handler' if candidates.nil? || candidates.empty?

--- a/bin/handler-twiliosms.rb
+++ b/bin/handler-twiliosms.rb
@@ -29,6 +29,9 @@ class TwilioSMS < Sensu::Handler
     from_number = settings['twiliosms']['number']
     candidates = settings['twiliosms']['recipients']
     short = settings['twiliosms']['short'] || false
+    disableOk = settings['twiliosms']['disableOk'] || false
+
+    next if @event['action'].eql?('resolve') and disableOk
 
     fail 'Please define a valid Twilio authentication set to use this handler' unless account_sid && auth_token && from_number
     fail 'Please define a valid set of SMS recipients to use this handler' if candidates.nil? || candidates.empty?


### PR DESCRIPTION
Not sure if I have a config issue somewhere, but the twilio handler gets called after occurences are met, even if there was no event raised for the check previously. Either I am doing something wrong, or this plugin isn't smart enough to know if it should resolve or not, or if sensu is suppose to manage it.
