### PR TITLE
Handle case when subscribers property of event.check data is nil

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 This CHANGELOG follows the format listed at [Keep A Changelog](http://keepachangelog.com/)
 
 ## [Unreleased]
+- handle case when event data does not have a subscribers property (Enables keepalive event handling support)
 
 ## [0.0.4] - 2016-04-26
 ### Fixed

--- a/bin/handler-twiliosms.rb
+++ b/bin/handler-twiliosms.rb
@@ -39,7 +39,8 @@ class TwilioSMS < Sensu::Handler
     recipients = []
     candidates.each do |mobile, candidate|
       next unless (candidate['sensu_roles'].include?('all') ||
-          ((candidate['sensu_roles'] & @event['check']['subscribers']).size > 0) || # rubocop:disable Style/ZeroLengthPredicate
+          (@event['check']['name'].eql?('keepalive') && candidate['sensu_roles'].include?('keepalive')) ||
+          (@event['check']['subscribers'] && (candidate['sensu_roles'] & @event['check']['subscribers']).size > 0) || # rubocop:disable Style/ZeroLengthPredicate
           candidate['sensu_checks'].include?(@event['check']['name'])) &&
                   (candidate['sensu_level'] >= @event['check']['status'])
       recipients << mobile

--- a/bin/handler-twiliosms.rb
+++ b/bin/handler-twiliosms.rb
@@ -40,7 +40,8 @@ class TwilioSMS < Sensu::Handler
     candidates.each do |mobile, candidate|
       next unless (candidate['sensu_roles'].include?('all') ||
           (@event['check']['name'].eql?('keepalive') && candidate['sensu_roles'].include?('keepalive')) ||
-          (@event['check']['subscribers'] && (candidate['sensu_roles'] & @event['check']['subscribers']).size > 0) || # rubocop:disable Style/ZeroLengthPredicate
+          (@event['check']['subscribers'] &&
+            (candidate['sensu_roles'] & @event['check']['subscribers']).size > 0) || # rubocop:disable Style/ZeroLengthPredicate
           candidate['sensu_checks'].include?(@event['check']['name'])) &&
                   (candidate['sensu_level'] >= @event['check']['status'])
       recipients << mobile


### PR DESCRIPTION
When handling keepalive events for example subscribers property is nil. Handle this case + add a special "keepalive" role to enable receiving notifications about keepalive events.
