### PR TITLE
Allow user to specify which level(s) of event will send a message

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,12 +24,17 @@
       "+11111111111": {
         "sensu_roles":[ "web-server" ], // subscribers
         "sensu_checks":[], // checks
-        "sensu_level": 1 // 1 for warnging, 2 for critical alerts
+        "sensu_level": [1] // 1 for warning only
       },
       "+11111222222": {
         "sensu_roles":[],
         "sensu_checks":[ "mysql-alive" ],
-        "sensu_level": 2
+        "sensu_level": [2] // 2 for critical only
+      },
+      "+11111333333": {
+        "sensu_roles":[],
+        "sensu_checks":[ "mysql-alive" ],
+        "sensu_level": [1, 2] // 1 and 2 for warnings and criticals
       }
     }
   }

--- a/bin/handler-twiliosms.rb
+++ b/bin/handler-twiliosms.rb
@@ -43,7 +43,7 @@ class TwilioSMS < Sensu::Handler
           (@event['check']['subscribers'] &&
             (candidate['sensu_roles'] & @event['check']['subscribers']).size > 0) || # rubocop:disable Style/ZeroLengthPredicate
           candidate['sensu_checks'].include?(@event['check']['name'])) &&
-                  (candidate['sensu_level'] >= @event['check']['status'])
+                  (candidate['sensu_level'].include? @event['check']['status']) || (@event['check']['status'] == 0)
       recipients << mobile
     end
 


### PR DESCRIPTION
## Pull Request Checklist

**Is this in reference to an existing issue?**

#### General

- [ ] Update Changelog following the conventions laid out on [Keep A Changelog](http://keepachangelog.com/)

- [ ] Update README with any necessary configuration snippets

- [ ] Binstubs are created if needed

- [ ] RuboCop passes

- [ ] Existing tests pass 

#### New Plugins

- [ ] Tests

- [ ] Add the plugin to the README

- [ ] Does it have a complete header as outlined [here](http://sensu-plugins.io/docs/developer_guidelines.html#coding-style)

#### Purpose

In my use case, I want to send e-mails on warnings and sms(twilio) on critical. 
My change allows you to specify warnings, critical, or both event types. 

#### Known Compatablity Issues

This is a breaking change as sensu_level is changed from int to array

